### PR TITLE
Testing, Logging, expand & delayed contract in run

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.onUse(function (api) {
   api.versionsFrom("1.0.1");
   api.use(["mongo", "minimongo"]);
-  api.use(["underscore", "check"]);
+  api.use(["underscore", "check", "mrt:moment"]);
 
   api.addFiles("shared/index.js", ["client", "server"]);
 

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ Migrations.add = function (migration) {
 
   check(migration, {
     name: String,
+    required: Match.Optional(Function),
     expand: Function,
     description: Match.Optional(String),
     contract: Match.Optional(Function)
@@ -23,6 +24,7 @@ Migrations.add = function (migration) {
   self.collection.upsert({name: migration.name}, {$set: {name: migration.name}});
 
   self._migrations[migration.name] = {
+    required: migration.required,
     expand: migration.expand,
     contract: migration.contract
   };

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -1,3 +1,11 @@
+Migrations.setContractDelay = function (delay) {
+  Migrations.contractDelay = delay;
+};
+
+Migrations.getContractDelay = function () {
+  return Migrations.contractDelay === undefined ? 60 : Migrations.contractDelay;
+};
+
 Migrations.run = function () {
 
   console.log("Beginning DB Migrations");
@@ -10,8 +18,6 @@ Migrations.run = function () {
     unexpanded.forEach(runExpand);
   }
 
-  Migrations.contractDelay = 5
-
   Meteor.setTimeout(function() {
     var uncontracted = uncontractedMigrations();
     if (uncontracted.length === 0) {
@@ -20,7 +26,7 @@ Migrations.run = function () {
       console.log("  Applying contract migrations", uncontracted);
       uncontracted.forEach(runContract);
     }
-  }, Migrations.contractDelay*1000)
+  }, (Migrations.getContractDelay()*1000) + 1)
 
   // // debugging variables
   Migrations.unexpanded = unexpandedMigrations;

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -2,19 +2,33 @@ Migrations.run = function () {
 
   console.log("Beginning DB Migrations");
 
-  var unstarted = unstartedMigrations();
-  if(unstarted.length === 0){
-    console.log("No migrations to apply");
-    return
+  console.log(Migrations._migrations)
+  var unexpanded = unexpandedMigrations();
+  if (unexpanded.length === 0) {
+    console.log("No expand migrations found");
+  } else {
+    console.log("Applying migrations", unexpanded);
+    unexpanded.forEach(runExpand);
   }
 
-  console.log("Applying migrations", unstarted);
-
-  unstarted.forEach(runExpand);
+  var uncontracted = uncontractedMigrations();
+  if (uncontracted.length === 0) {
+    console.log("No contract migrations found")
+  } else {
+    console.log("Applying migrations", uncontracted);
+    uncontracted.forEach(runContract);
+  }
 
   // // debugging variables
-  Migrations.unstarted = unstartedMigrations;
+  Migrations.unexpanded = unexpandedMigrations;
+  Migrations.uncontracted = uncontractedMigrations;
 };
+
+// Return true is exend has been run successfully
+Migrations.isExpanded = function(name) {
+  return Migrations.collection.find(
+    {name: name, expandCompletedAt: {$exists: true}}).count() > 0
+}
 
 // Remove all memory of migrations, allow 'add's to take effect
 // INTENDED FOR TEST/DEV USE ONLY
@@ -28,12 +42,26 @@ Migrations._reset = function (sameProcess) {
   sameProcess || process.exit(); //it comes back, don't worry
 };
 
-function unstartedMigrations () {
-  var pending = Migrations.collection.find({
-    expandStartedAt: {$exists: false}
-  }, {$sort: {name: 1}});
+function unexpandedMigrations () {
+  var pending = Migrations.collection.find(
+    {expandStartedAt: {$exists: false}},
+    {$sort: {name: 1}});
 
   return pending.fetch().map(function (m) { return m.name });
+}
+
+function uncontractedMigrations () {
+  var pending = Migrations.collection.find(
+    { contractStartedAt: {$exists: false}},
+    {$sort: {name: 1}});
+
+  var names = pending.fetch().map(function (m) { return m.name });
+  console.log(names)
+  return _.select(names, function(name) {
+    console.log(name)
+    console.log(Migrations._migrations[name])
+    return Migrations._migrations[name].contract !== undefined
+  })
 }
 
 function log(phase,name,state) {
@@ -49,16 +77,20 @@ function runExpand (name) {
 }
 
 function requirementsMet(name) {
+  console.log(name,Migrations._migrations[name])
   var requiredFn = Migrations._migrations[name].required
   return requiredFn ? requiredFn() : true
 }
 
 function runContract (name) {
-  runPhase("contract", name);
+  if (Migrations.isExpanded(name))
+    runPhase("contract", name);
+  else
+    log("contract", name, "preempted: expand incomplete")
 }
 
 function runPhase (phase, name) {
-  console.log(phase, name, "is running");
+  log(phase, name, "is running");
   var phaseFn = Migrations._migrations[name][phase];
 
   timestamp(name, phase, "StartedAt");

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -36,8 +36,21 @@ function unstartedMigrations () {
   return pending.fetch().map(function (m) { return m.name });
 }
 
+function log(phase,name,state) {
+  var now = moment().format("YYYY-MM-DD h:mma")
+  console.log("--- "+now+" - migration "+phase+" phase of: "+name+" - "+state)
+}
+
 function runExpand (name) {
-  runPhase("expand", name);
+  if (requirementsMet(name))
+    runPhase("expand", name)
+  else
+    log("expand", name, "prepempted: no records")
+}
+
+function requirementsMet(name) {
+  var requiredFn = Migrations._migrations[name].required
+  return requiredFn ? requiredFn() : true
 }
 
 function runContract (name) {
@@ -45,7 +58,7 @@ function runContract (name) {
 }
 
 function runPhase (phase, name) {
-  console.log("running " + phase + " phase of:", name);
+  console.log(phase, name, "is running");
   var phaseFn = Migrations._migrations[name][phase];
 
   timestamp(name, phase, "StartedAt");

--- a/server/startup.js
+++ b/server/startup.js
@@ -1,4 +1,6 @@
 // In dev/prod, run migrations on startup. Tests should call Migrations.run
 // XXX is this the best way to detect test mode?
 if (typeof Tinytest === "undefined")
-  Meteor.startup(Migrations.run);
+  Meteor.startup(function () {
+    Meteor.defer(Migrations.run);
+  });

--- a/tests/server/index.js
+++ b/tests/server/index.js
@@ -6,14 +6,12 @@ Tinytest.add("Migrations - API - add - full", function (test) {
   Migrations.add({
     name: 'full',
     description: 'full_desc',
-    required: function() {},
     expand: function() {},
     contract: function() {}
   })
   var migration = Migrations._migrations["full"]
   test.isNotNull(migration, "Migration not found")
   test.isNotNull(migration.description, "description expected")
-  test.isTrue(_.isFunction(migration.required), "required fn expected")
   test.isTrue(_.isFunction(migration.expand), "expand fn expected")
   test.isTrue(_.isFunction(migration.contract), "contract fn expected")
 });

--- a/tests/server/index.js
+++ b/tests/server/index.js
@@ -1,3 +1,30 @@
-Tinytest.add("Migrations - API - add", function (test) {
+Tinytest.add("Migrations - API - add - present", function (test) {
   test.equal(true, _.isFunction(Migrations.add));
+});
+
+Tinytest.add("Migrations - API - add - full", function (test) {
+  Migrations.add({
+    name: 'full',
+    description: 'full_desc',
+    required: function() {},
+    expand: function() {},
+    contract: function() {}
+  })
+  var migration = Migrations._migrations["full"]
+  test.isNotNull(migration, "Migration not found")
+  test.isNotNull(migration.description, "description expected")
+  test.isTrue(_.isFunction(migration.required), "required fn expected")
+  test.isTrue(_.isFunction(migration.expand), "expand fn expected")
+  test.isTrue(_.isFunction(migration.contract), "contract fn expected")
+});
+
+Tinytest.add("Migrations - API - add - optional", function (test) {
+  test.equal(true, _.isFunction(Migrations.add));
+  Migrations.add({
+    name: 'optional',
+    expand: function() {}
+  })
+  var migration = Migrations._migrations["optional"]
+  test.isNotNull(migration, "Migration not found")
+  test.isTrue(_.isFunction(migration.expand), "expand fn expected")
 });

--- a/tests/server/migrate.js
+++ b/tests/server/migrate.js
@@ -20,29 +20,3 @@ Tinytest.add("Migrations - Full Cycle - allowed", function (test) {
 
   Migrations._reset(true);
 });
-
-Tinytest.add("Migrations - Full Cycle - preempted", function (test) {
-  var x = 0;
-  var y = 0;
-  Migrations._reset(true);
-  Migrations.add({
-    name: "testFullPreempt",
-    required: function() {
-      return false
-    },
-    expand: function () {
-      x = x+1;
-    },
-    contract: function() {
-      y = y+1;
-    }
-  });
-
-  test.equal(x, 0, 'expand initial');
-  test.equal(y, 0, 'contact initial');
-  Migrations.run();
-  test.equal(x, 0, 'expand was preempted');
-  test.equal(y, 0, 'contract was run when expand was prempted');
-
-  Migrations._reset(true);
-});

--- a/tests/server/migrate.js
+++ b/tests/server/migrate.js
@@ -1,14 +1,48 @@
-Tinytest.add("Migrations - Full Cycle", function (test) {
+Tinytest.add("Migrations - Full Cycle - allowed", function (test) {
   var x = 0;
+  var y = 0;
   Migrations._reset(true);
   Migrations.add({
-    name: "test1",
+    name: "testFullAllow",
     expand: function () {
       x = x+1;
+    },
+    contract: function() {
+      y = y+1;
     }
   });
 
-  test.equal(x, 0);
+  test.equal(x, 0, 'expand initial');
+  test.equal(y, 0, 'contact initial');
   Migrations.run();
-  test.equal(x, 1);
+  test.equal(x, 1, 'expand was run');
+  test.equal(y, 1, 'contract was run');
+
+  Migrations._reset(true);
+});
+
+Tinytest.add("Migrations - Full Cycle - preempted", function (test) {
+  var x = 0;
+  var y = 0;
+  Migrations._reset(true);
+  Migrations.add({
+    name: "testFullPreempt",
+    required: function() {
+      return false
+    },
+    expand: function () {
+      x = x+1;
+    },
+    contract: function() {
+      y = y+1;
+    }
+  });
+
+  test.equal(x, 0, 'expand initial');
+  test.equal(y, 0, 'contact initial');
+  Migrations.run();
+  test.equal(x, 0, 'expand was preempted');
+  test.equal(y, 0, 'contract was run when expand was prempted');
+
+  Migrations._reset(true);
 });

--- a/tests/server/migrate.js
+++ b/tests/server/migrate.js
@@ -1,4 +1,7 @@
-Tinytest.add("Migrations - Full Cycle - allowed", function (test) {
+Tinytest.addAsync("Migrations - Full Cycle - allowed", function (test, next) {
+
+  Migrations.setContractDelay(0);
+
   var x = 0;
   var y = 0;
   Migrations._reset(true);
@@ -15,8 +18,11 @@ Tinytest.add("Migrations - Full Cycle - allowed", function (test) {
   test.equal(x, 0, 'expand initial');
   test.equal(y, 0, 'contact initial');
   Migrations.run();
-  test.equal(x, 1, 'expand was run');
-  test.equal(y, 1, 'contract was run');
+  Meteor.setTimeout(function () {
+    test.equal(x, 1, 'expand was run');
+    test.equal(y, 1, 'contract was run');  //make this pass on a set interval
 
-  Migrations._reset(true);
+    Migrations._reset(true);
+    next();
+  }, 500)
 });


### PR DESCRIPTION
Expand and Contract both in run, contract is delayed by a configurable number of seconds.

Tiny tests added to provife full coverage - but there's still a tinytest-timeout wait race in reporting. Reporting delays are ad hoc rather than gated by test completion.

Logging enhanced to added timestamp and include status.

Ready for single-processor migration latching.
